### PR TITLE
fix : 텍스트 개행, 기종에 따라 이미지 크기 맞게 변경되도록 수정하기

### DIFF
--- a/src/components/screens/ShootingGuide.tsx
+++ b/src/components/screens/ShootingGuide.tsx
@@ -84,6 +84,7 @@ const ShootingGuide = () => {
           data={shootingGuideData}
           horizontal
           pagingEnabled
+          style={{height: 500}}
           keyExtractor={(_, index) => index.toString()}
           renderItem={({ item }) => (
             <View style={styles.slideImageWrapper}>
@@ -148,15 +149,16 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
     backgroundColor: "#fff",
-    flex: 1,
-    top: -5
+    top: -5,
+    width:Dimensions.get('window').width,
+    height: "100%"
   },
 
   // header
   noteHead: {
     paddingBottom: 2,
     color: '#000',
-    fontSize: font(14),
+    fontSize: font(16),
     fontFamily: os.font(600, 700),
     includeFontPadding: false,
   },
@@ -171,7 +173,8 @@ const styles = StyleSheet.create({
   slideImageWrapper: {
     alignItems: "center",
     width: width,
-    marginTop: 10
+    height: "100%",
+    marginTop: 10,
   },
   indicatorContainer: {
     flexDirection: 'row',
@@ -190,22 +193,27 @@ const styles = StyleSheet.create({
   },
 
   slideImg: {
-    width: '50%',       // 슬라이드 너비를 기준으로
-    height: undefined,   // 높이 자동 계산
-    aspectRatio: 1,      // 또는 원본 비율 (예: 16/9)
+    width: width * 0.5,
+    height: "50%",   // 높이 자동 계산
+    aspectRatio: 1,               // 정사각형
+    resizeMode: 'contain',
+    alignSelf: 'center',
   },
 
   // 하단 텍스트
   ShootingGuideBottom: {
     position: "relative",
     alignItems: "center",
+    justifyContent: "center",
+    height: "10%",
     gap: 10,
     fontFamily: os.font(500, 500),
-    top: -20
+    top: -30
   },
   mainDescription: {
     textAlign: "center",
     fontWeight: "700",
+    color: "#333",
     fontSize: font(16),
     fontFamily: os.font(500, 500),
   },

--- a/src/constants/guide.ts
+++ b/src/constants/guide.ts
@@ -6,13 +6,13 @@ const shootingGuideData= [
     subImage: require('@/assets/images/search_step1_sub.png') },
   {
     title: '알약에 글자가 선명히 보이도록 촬영해주세요',
-    description: '알약의 글자가 잘리거나 흐리게 촬영하면 정확한 결과가 안나올 수 있어요',
+    description: '알약의 글자가 잘리거나 흐리게 촬영하면\n정확한 결과가 안나올 수 있어요',
     mainImage: require('@/assets/images/search_step2_main.png'),
     subImage: require('@/assets/images/search_step2_sub.png')
   },
   {
     title: '알약은 하나씩만 찍어주세요.',
-    description: '붙어있거나 겹쳐있으면 정확한 결과가 안나올 수 있어요',
+    description: '붙어있거나 겹쳐있으면\n정확한 결과가 안나올 수 있어요',
     mainImage: require('@assets/images/search_step3_main.png'),
     subImage: require('@/assets/images/search_step3_sub.png') },
 ];


### PR DESCRIPTION
# 연관 이슈

<img width="256" alt="image" src="https://github.com/user-attachments/assets/46989d92-456a-4596-8f1a-b3cbd4d3f659" />


- #66 
- 기종에 따라 이미지 크기가 맞지 않는 문제가 있어서 수정

# 작업 내용

- 이미지 크기 화면 비율에 맞게 수정

# 참고 자료

-

# 비고

-
