### PR TITLE
style : 사전 출시 보고서의 접근성 관련 스타일 속성 수정

### DIFF
--- a/src/components/atoms/UpdateText.tsx
+++ b/src/components/atoms/UpdateText.tsx
@@ -29,7 +29,7 @@ const UpdateText = () => {
     updateText: {
       fontFamily: os.font(400, 400),
       fontSize: font(14),
-      color: '#777',
+      color: '#444',
       includeFontPadding: false,
     },
   });

--- a/src/components/organisms/LastSearchPill.tsx
+++ b/src/components/organisms/LastSearchPill.tsx
@@ -122,7 +122,7 @@ const styles = StyleSheet.create({
     height: '100%',
   },
   noListText: {
-    color: '#969696',
+    color: '#444',
     fontSize: font(14),
     fontFamily: os.font(400, 400),
     includeFontPadding: false,

--- a/src/components/organisms/MenuList.tsx
+++ b/src/components/organisms/MenuList.tsx
@@ -74,7 +74,7 @@ const styles = StyleSheet.create({
     fontSize: font(12),
     fontFamily: os.font(500, 500),
     textAlign: 'right',
-    textShadowColor: 'rgba(0, 0, 0, 0.5)',
+    textShadowColor: 'rgba(0, 0, 0, 0.8)',
     textShadowOffset: { width: 0, height: 0 },
     textShadowRadius: 25,
     paddingRight: 16,

--- a/src/components/organisms/SearchIdInput.tsx
+++ b/src/components/organisms/SearchIdInput.tsx
@@ -53,7 +53,7 @@ const styles = StyleSheet.create({
     paddingBottom: 4,
     fontSize: font(14),
     fontFamily: os.font(600, 700),
-    color: "#7472EB",
+    color: "#4D4DAD",
     includeFontPadding: false
   },
   sectionTextInputSplitWrapper: {
@@ -68,12 +68,12 @@ const styles = StyleSheet.create({
     paddingStart: 16,
     borderWidth: 2,
     borderRadius: 8,
-    borderColor: '#858585',
+    borderColor: '#444',
     fontSize: font(16),
     fontFamily: os.font(700, 800),
     includeFontPadding: false,
     maxHeight: font(16 * 3),
-    color: "#000",
+    color: "#444",
     backgroundColor: '#fff'
   },
   sectionErrorWrapper: {

--- a/src/components/organisms/SearchIdList.tsx
+++ b/src/components/organisms/SearchIdList.tsx
@@ -135,8 +135,8 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: 8,
     borderWidth: 1.5,
-    borderColor: '#7472EB',
-    backgroundColor: '#7472EB'
+    borderColor: '#6563ed',
+    backgroundColor: '#6563ed'
   },
   buttonText: {
     fontSize: font(16),

--- a/src/components/screens/SearchCamera.tsx
+++ b/src/components/screens/SearchCamera.tsx
@@ -455,7 +455,7 @@ const SearchCamera = (): JSX.Element => {
             color: '#FF6868',
         },
         noteBack: {
-            color: '#8598FF',
+            color: '#75a3ec',
         },
         noteComplete: {
             color: '#fffa5f',

--- a/src/components/screens/Settings.tsx
+++ b/src/components/screens/Settings.tsx
@@ -123,7 +123,7 @@ const styles = StyleSheet.create({
         paddingBottom: 0,
     },
     subText: {
-        color: '#aaa',
+        color: '#444',
     },
     rightArrow: {
     },

--- a/src/components/screens/Storage.tsx
+++ b/src/components/screens/Storage.tsx
@@ -55,7 +55,7 @@ const Storage = (): JSX.Element => {
         numberText: {
             fontSize: font(14),
             fontFamily: os.font(500, 500),
-            color: '#848484',
+            color: '#444',
             includeFontPadding: false,
             paddingBottom: 0,
         },


### PR DESCRIPTION
# 연관 이슈

- #87 

# 작업 내용

>TODO : 추후에 색상 소스 모듈화 시켜서 합치려 합니다!

- 텍스트 대비 같은 경우 #444 색상으로 수정했습니다.
- 보라색 텍스트 같은 경우 #4D4D4D 색상 또는 #75a3ec으로 수정했습니다.
- 텍스트가 흰색인데 대비 문제인 버튼 색상은 #6563ed으로 수정했습니다.
- 메인의 subTitle 은 텍스트의 shadowColor의 투명도를 0.5 -> 0.8로 수정했습니다.
- 아래 이미지의 pass 라고 적혀있는 곳은 잘못 인식되는 것 같아 처리하지 않았습니다.

<img width="1059" alt="Image" src="https://github.com/user-attachments/assets/5b0f96d2-6903-46b8-8351-74f9cd638b48" />

<img width="1077" alt="Image" src="https://github.com/user-attachments/assets/972660e3-ccbf-4da1-88bb-e33eacb39e05" />

<img width="791" alt="Image" src="https://github.com/user-attachments/assets/9e5493c9-0d76-4f75-834f-ba84c7956167" />

