### PR TITLE
fix : 버전 체크하는 부분 react-native-device-info 에서 비교하는 것 대신 react-native-v…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,13 +27,6 @@ const App = (): React.JSX.Element => {
   const [updateDB, setUpdateDB] = useState(false);
 
   useEffect(() => {
-    // 테스트로 앱 버전 바꿔보기
-    // AsyncStorage.setItem('app_version', '0.0.1'); // 현재보다 낮은 값
-    // 앱 버전 체크 (ios 는 아직 출시 안돼서 버전 검사하는 로직 실행 안되도록 분기처리)
-    if (Platform.OS !== 'ios') {
-      checkAppVersion();
-    }
-
     ignoreSpecificLogs();
 
     const subscription = AppState.addEventListener(
@@ -53,7 +46,6 @@ const App = (): React.JSX.Element => {
   };
 
   useEffect(() => {
-    // AsyncStorage.setItem('app_version', '0.0.1'); // 버전 낮추기 테스트용
     // 앱 버전 체크
     checkAppVersion();
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,6 @@ import { RealmProvider } from '@realm/react';
 import { dbConfig } from '@/api/db/config';
 import { AlertProvider } from '@/provider/AlertProvider';
 import { checkAppVersion } from '@/utils/versionChecker';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import wipConfig from '../wip_config.json';
 import { GLOBAL_STATE } from './global_state';
 

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,29 +1,19 @@
 import axiosInstance from '@api/index.ts';
-import { getToken } from '@api/client/auth.ts';
 
 export const apiClient = {
   get: async <T>(url: string, params?: object): Promise<T> => {
     const response = await axiosInstance.get<T>(url, {
-      headers: {
-        Authorization: `Bearer ${getToken()}`,
-        'Content-Type': 'application/json',
-      },
       params,
-      timeout: 1000 * 100,
     });
 
     return response.data;
   },
 
-  post: async <T>(url: string, data?: object): Promise<{ res: T; status: number, message: string }> => {
-    const response = await axiosInstance.post<T>(url, data, {
-      headers: {
-        Authorization: `Bearer ${getToken()}`,
-        'Content-Type': 'application/json',
-        apiVersion: 2,
-      },
-      timeout: 1000 * 150,
-    });
+  post: async <T>(
+    url: string,
+    data?: object,
+  ): Promise<{ res: T; status: number; message: string }> => {
+    const response = await axiosInstance.post<T>(url, data);
 
     return {
       res: response.data,

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,0 +1,34 @@
+import axiosInstance from '@api/index.ts';
+import { getToken } from '@api/client/auth.ts';
+
+export const apiClient = {
+  get: async <T>(url: string, params?: object): Promise<T> => {
+    const response = await axiosInstance.get<T>(url, {
+      headers: {
+        Authorization: `Bearer ${getToken()}`,
+        'Content-Type': 'application/json',
+      },
+      params,
+      timeout: 1000 * 100,
+    });
+
+    return response.data;
+  },
+
+  post: async <T>(url: string, data?: object): Promise<{ res: T; status: number, message: string }> => {
+    const response = await axiosInstance.post<T>(url, data, {
+      headers: {
+        Authorization: `Bearer ${getToken()}`,
+        'Content-Type': 'application/json',
+        apiVersion: 2,
+      },
+      timeout: 1000 * 150,
+    });
+
+    return {
+      res: response.data,
+      status: response.status,
+      message: (response.data as any).message ?? '',
+    };
+  },
+};

--- a/src/api/client/dbInfo.ts
+++ b/src/api/client/dbInfo.ts
@@ -1,15 +1,16 @@
-import axios from 'axios';
 import Config from 'react-native-config';
-import { getToken } from './auth';
+import { apiClient } from '@api/apiClient.ts';
+
+interface IInitInfo {
+  appStoreVersion: null | string;
+  playStoreVersion: null | string;
+  resourceDate: string;
+}
 
 const getDBInfo = async () => {
-  const token = getToken();
-
-  const res = await axios.get(Config.GOOGLE_CLOUD_INIT_INFO_URL as string, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-
-  return res.data;
+  return await apiClient.get<IInitInfo>(
+    Config.GOOGLE_CLOUD_INIT_INFO_URL as string,
+  );
 };
 
 export { getDBInfo };

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,23 @@
+import axios from 'axios';
+import { getToken } from '@api/client/auth.ts';
+
+const token = getToken();
+
+const axiosInstance = axios.create({
+  baseURL: '',
+  timeout: 10000,
+  headers: {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${token}`,
+    apiVersion: 2,
+  },
+});
+
+// TODO : 7월 말 회의 후 인터셉터에 있어야 하는 부분 추가하기
+// 요청 인터셉터
+axiosInstance.interceptors.request.use();
+
+// 응답 인터셉터
+axiosInstance.interceptors.response.use();
+
+export default axiosInstance;

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1,31 +1,14 @@
-import axios from 'axios';
 import Config from 'react-native-config';
-import { getToken } from './client/auth';
+import { apiClient } from '@api/apiClient.ts';
 
 const postImageServer = (base64: string | undefined) => {
-  return axios.post(
-    Config.GOOGLE_CLOUD_DL_SERVER_URL as string,
-    { base64 },
-    {
-      headers: {
-        Authorization: `Bearer ${getToken()}`,
-        'Content-Type': 'application/json',
-        apiVersion: 2,
-      },
-      timeout: 1000 * 150,
-    },
-  );
+  return apiClient.post(Config.GOOGLE_CLOUD_DL_SERVER_URL as string, {
+    base64,
+  });
 };
 
 const getDrugDetail = (URL: string, ITEM_SEQ: string) => {
-  return axios.get(URL, {
-    headers: {
-      Authorization: `Bearer ${getToken()}`,
-      'Content-Type': 'application/json',
-    },
-    params: { ITEM_SEQ: ITEM_SEQ },
-    timeout: 1000 * 100,
-  });
+  return apiClient.get(URL, { ITEM_SEQ: ITEM_SEQ });
 };
 
 export { postImageServer, getDrugDetail };

--- a/src/components/screens/PillDetail.tsx
+++ b/src/components/screens/PillDetail.tsx
@@ -73,26 +73,25 @@ const PillDetail = ({ route }: any): JSX.Element => {
   const getDetailData = async () => {
     const URL = `${Config.GOOGLE_CLOUD_DRUG_DETAIL_URL}`;
     const itemSeq = data.ITEM_SEQ;
-    await getDrugDetail(URL, itemSeq)
-      .then((val) => {
-        const parsedData = {
-          EE: parseXML(val.data.EE_DOC_DATA),
-          UD: parseXML(val.data.UD_DOC_DATA),
-          NB: parseXML(val.data.NB_DOC_DATA),
-        };
+    const val: any = await getDrugDetail(URL, itemSeq);
 
-        setInfoData(parsedData);
-      })
-      .catch((err) => {
-        console.error(err);
-        Toast.show({
-          type: 'errorToast',
-          text1: '상세정보를 가져오는데 문제가 생겼습니다.',
-        });
-      })
-      .finally(() => {
-        setLoading(false);
+    try {
+      const parsedData = {
+        EE: parseXML(val.EE_DOC_DATA),
+        UD: parseXML(val.UD_DOC_DATA),
+        NB: parseXML(val.NB_DOC_DATA),
+      };
+
+      setInfoData(parsedData);
+    } catch (err) {
+      console.error(err);
+      Toast.show({
+        type: 'errorToast',
+        text1: '상세정보를 가져오는데 문제가 생겼습니다.',
       });
+    } finally {
+      setLoading(false);
+    }
   };
 
   // [임시] 테스트를 위한 MockData

--- a/src/utils/checker.ts
+++ b/src/utils/checker.ts
@@ -1,6 +1,9 @@
 import _ from 'lodash';
+import { Platform } from "react-native";
 
 const regexPattern = /[*?]/;
+
+export const isIos = Platform.OS === 'ios';
 
 export const disableWord = (text: string) => {
   return regexPattern.test(text);

--- a/src/utils/checker.ts
+++ b/src/utils/checker.ts
@@ -1,9 +1,9 @@
 import _ from 'lodash';
-import { Platform } from "react-native";
+import { Platform } from 'react-native';
 
 const regexPattern = /[*?]/;
 
-export const isIos = Platform.OS === 'ios';
+export const isIos: boolean = Platform.OS === 'ios';
 
 export const disableWord = (text: string) => {
   return regexPattern.test(text);

--- a/src/utils/versionChecker.ts
+++ b/src/utils/versionChecker.ts
@@ -12,7 +12,7 @@ import DeviceInfo from 'react-native-device-info';
 import { isIos } from '@/utils/checker.ts';
 import { apiClient } from '@api/apiClient.ts';
 
-let originVersion = '';
+let fetchedVersion = '';
 
 // 버전 업데이트 버튼 클릭 시 이동될 url
 const openStore = () => {
@@ -29,35 +29,25 @@ const openStore = () => {
   RNExitApp.exitApp();
 };
 
-const versionToNumber = (version: string) => {
-  const parts = version.split('.').map(Number);
-  const [major = 0, minor = 0, patch = 0] = parts;
-
-  return major * 10000 + minor * 100 + patch;
-};
-
 const fetchLatestVersion = async () => {
   const { appStoreVersion, playStoreVersion }: IAppVersion =
     await apiClient.get(Config.GOOGLE_CLOUD_INIT_INFO_URL as string);
 
   // ios, android 각각 버전 가져오기
-  originVersion = isIos ? String(appStoreVersion) : String(playStoreVersion);
-  return originVersion;
+  fetchedVersion = isIos ? String(appStoreVersion) : String(playStoreVersion);
+  return fetchedVersion;
 };
 
 // 앱 버전 체크하는 함수
 export const checkAppVersion = async () => {
-  // ios 일 땐 return 시켜주기 ios 배포되면 주석 해제
-  if (isIos) return;
-
-  const latestVersion = versionToNumber(await fetchLatestVersion());
-  const currentVersion = versionToNumber(String(DeviceInfo.getVersion()));
+  const latestVersionNumber = await fetchLatestVersion();
+  const currentVersionNumber = String(DeviceInfo.getVersion());
 
   try {
-    if (latestVersion !== currentVersion) {
+    if (latestVersionNumber !== currentVersionNumber) {
       Alert.alert(
         '업데이트 안내',
-        `앱이 업데이트되었습니다.\n업데이트 후 사용해주세요. 새로운 버전: ${originVersion}`,
+        `앱이 업데이트되었습니다.\n업데이트 후 사용해주세요.\n\n현재 버전: ${currentVersionNumber} \n새로운 버전: ${latestVersionNumber}`,
         [{ text: '업데이트 하러 가기', onPress: openStore }],
       );
     }

--- a/src/utils/versionChecker.ts
+++ b/src/utils/versionChecker.ts
@@ -1,26 +1,8 @@
 // utils/versionChecker.ts
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import DeviceInfo from 'react-native-device-info';
+import VersionCheck from 'react-native-version-check';
 import { Alert } from 'react-native';
 import { Linking, Platform } from 'react-native';
 import RNExitApp from 'react-native-exit-app';
-
-// AsyncStorage 앱 버전 저장한 데이터의 key 값
-const VERSION_KEY = 'app_version';
-
-const parseVersion = (version: string) => {
-  const [major, minor, patch] = version.split('.').map(Number);
-  return { major, minor, patch };
-};
-
-// 버전 변경 감지 기준
-const isVersionChanged = (saved: any, current: any) => {
-  return (
-    saved.major !== current.major ||
-    saved.minor !== current.minor ||
-    saved.patch !== current.patch
-  );
-};
 
 // 버전 업데이트 버튼 클릭 시 이동될 url
 const openStore = () => {
@@ -42,29 +24,23 @@ export const checkAppVersion = async () => {
   // ios 일 땐 return 시켜주기
   if (Platform.OS === 'ios') return;
 
+  const latestVersion = await VersionCheck.getLatestVersion();
+  const currentVersion = VersionCheck.getCurrentVersion();
+
   try {
     // ex: "1.2.3"
-    const currentVersion = DeviceInfo.getVersion();
-    // AsyncStorage에서 저장한 앱 버전 가져오기
-    const savedVersion = await AsyncStorage.getItem(VERSION_KEY);
-
-    if (!savedVersion) {
-      await AsyncStorage.setItem(VERSION_KEY, currentVersion);
-      return;
-    }
-
-    const saved = parseVersion(savedVersion);
-    const current = parseVersion(currentVersion);
-
     // 버전 확인
-    if (isVersionChanged(saved, current)) {
+    const versionState = await VersionCheck.needUpdate({
+      currentVersion,
+      latestVersion,
+    });
+
+    if (versionState) {
       Alert.alert(
         '업데이트 안내',
         `앱이 업데이트되었습니다.\n업데이트 후 사용해주세요. 새로운 버전: ${currentVersion}`,
         [{ text: '업데이트 하러 가기', onPress: openStore }],
       );
-
-      await AsyncStorage.setItem(VERSION_KEY, currentVersion);
     }
   } catch (e) {
     console.error('버전 체크 중 오류:', e);

--- a/src/utils/versionChecker.ts
+++ b/src/utils/versionChecker.ts
@@ -41,13 +41,13 @@ const fetchLatestVersion = async () => {
 // 앱 버전 체크하는 함수
 export const checkAppVersion = async () => {
   const latestVersion = await fetchLatestVersion();
-  const currentVersionNumber = String(DeviceInfo.getVersion());
+  const currentVersion = String(DeviceInfo.getVersion());
 
   try {
-    if (latestVersion !== currentVersionNumber) {
+    if (latestVersion !== currentVersion) {
       Alert.alert(
         '업데이트 안내',
-        `앱이 업데이트되었습니다.\n업데이트 후 사용해주세요.\n\n현재 버전: ${currentVersionNumber} \n새로운 버전: ${latestVersion}`,
+        `앱이 업데이트되었습니다.\n업데이트 후 사용해주세요.\n\n현재 버전: ${currentVersion} \n새로운 버전: ${latestVersion}`,
         [{ text: '업데이트 하러 가기', onPress: openStore }],
       );
     }

--- a/src/utils/versionChecker.ts
+++ b/src/utils/versionChecker.ts
@@ -1,12 +1,18 @@
+interface IAppVersion {
+  appStoreVersion: string;
+  playStoreVersion: string;
+}
+
 // utils/versionChecker.ts
 import { Alert } from 'react-native';
 import { Linking, Platform } from 'react-native';
 import RNExitApp from 'react-native-exit-app';
-import { getToken } from "@api/client/auth.ts";
-import axios from "axios";
-import Config from "react-native-config";
-import DeviceInfo from "react-native-device-info";
-import { isIos } from "@/utils/checker.ts";
+import Config from 'react-native-config';
+import DeviceInfo from 'react-native-device-info';
+import { isIos } from '@/utils/checker.ts';
+import { apiClient } from '@api/apiClient.ts';
+
+let originVersion = '';
 
 // 버전 업데이트 버튼 클릭 시 이동될 url
 const openStore = () => {
@@ -31,20 +37,12 @@ const versionToNumber = (version: string) => {
 };
 
 const fetchLatestVersion = async () => {
-  const token = getToken();
-  const response = await axios.get(
-    Config.GOOGLE_CLOUD_INIT_INFO_URL as string,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    },
-  );
+  const { appStoreVersion, playStoreVersion }: IAppVersion =
+    await apiClient.get(Config.GOOGLE_CLOUD_INIT_INFO_URL as string);
 
   // ios, android 각각 버전 가져오기
-  return isIos
-    ? String(response.data.appStoreVersion)
-    : String(response.data.playStoreVersion);
+  originVersion = isIos ? String(appStoreVersion) : String(playStoreVersion);
+  return originVersion;
 };
 
 // 앱 버전 체크하는 함수
@@ -59,7 +57,7 @@ export const checkAppVersion = async () => {
     if (latestVersion !== currentVersion) {
       Alert.alert(
         '업데이트 안내',
-        `앱이 업데이트되었습니다.\n업데이트 후 사용해주세요. 새로운 버전: ${latestVersion}`,
+        `앱이 업데이트되었습니다.\n업데이트 후 사용해주세요. 새로운 버전: ${originVersion}`,
         [{ text: '업데이트 하러 가기', onPress: openStore }],
       );
     }

--- a/src/utils/versionChecker.ts
+++ b/src/utils/versionChecker.ts
@@ -44,7 +44,7 @@ export const checkAppVersion = async () => {
   const currentVersionNumber = String(DeviceInfo.getVersion());
 
   try {
-    if (latestVersionNumber !== currentVersionNumber) {
+    if (latestVersionNumber > currentVersionNumber) {
       Alert.alert(
         '업데이트 안내',
         `앱이 업데이트되었습니다.\n업데이트 후 사용해주세요.\n\n현재 버전: ${currentVersionNumber} \n새로운 버전: ${latestVersionNumber}`,

--- a/src/utils/versionChecker.ts
+++ b/src/utils/versionChecker.ts
@@ -40,14 +40,14 @@ const fetchLatestVersion = async () => {
 
 // 앱 버전 체크하는 함수
 export const checkAppVersion = async () => {
-  const latestVersionNumber = await fetchLatestVersion();
+  const latestVersion = await fetchLatestVersion();
   const currentVersionNumber = String(DeviceInfo.getVersion());
 
   try {
-    if (latestVersionNumber > currentVersionNumber) {
+    if (latestVersion !== currentVersionNumber) {
       Alert.alert(
         '업데이트 안내',
-        `앱이 업데이트되었습니다.\n업데이트 후 사용해주세요.\n\n현재 버전: ${currentVersionNumber} \n새로운 버전: ${latestVersionNumber}`,
+        `앱이 업데이트되었습니다.\n업데이트 후 사용해주세요.\n\n현재 버전: ${currentVersionNumber} \n새로운 버전: ${latestVersion}`,
         [{ text: '업데이트 하러 가기', onPress: openStore }],
       );
     }

--- a/src/utils/versionChecker.ts
+++ b/src/utils/versionChecker.ts
@@ -6,6 +6,7 @@ import { getToken } from "@api/client/auth.ts";
 import axios from "axios";
 import Config from "react-native-config";
 import DeviceInfo from "react-native-device-info";
+import { isIos } from "@/utils/checker.ts";
 
 // 버전 업데이트 버튼 클릭 시 이동될 url
 const openStore = () => {
@@ -29,14 +30,9 @@ const versionToNumber = (version: string) => {
   return major * 10000 + minor * 100 + patch;
 };
 
-// 앱 버전 체크하는 함수
-export const checkAppVersion = async () => {
-  // ios 일 땐 return 시켜주기
-  if (Platform.OS === 'ios') return;
-
+const fetchLatestVersion = async () => {
   const token = getToken();
-
-  const initInfoData = await axios.get(
+  const response = await axios.get(
     Config.GOOGLE_CLOUD_INIT_INFO_URL as string,
     {
       headers: {
@@ -45,17 +41,25 @@ export const checkAppVersion = async () => {
     },
   );
 
-  const latestVersion = versionToNumber(
-    String(initInfoData.data.playStoreVersion),
-  );
+  // ios, android 각각 버전 가져오기
+  return isIos
+    ? String(response.data.appStoreVersion)
+    : String(response.data.playStoreVersion);
+};
 
+// 앱 버전 체크하는 함수
+export const checkAppVersion = async () => {
+  // ios 일 땐 return 시켜주기 ios 배포되면 주석 해제
+  if (isIos) return;
+
+  const latestVersion = versionToNumber(await fetchLatestVersion());
   const currentVersion = versionToNumber(String(DeviceInfo.getVersion()));
 
   try {
     if (latestVersion !== currentVersion) {
       Alert.alert(
         '업데이트 안내',
-        `앱이 업데이트되었습니다.\n업데이트 후 사용해주세요. 새로운 버전: ${initInfoData.data.playStoreVersion}`,
+        `앱이 업데이트되었습니다.\n업데이트 후 사용해주세요. 새로운 버전: ${latestVersion}`,
         [{ text: '업데이트 하러 가기', onPress: openStore }],
       );
     }


### PR DESCRIPTION
…ersion-check를 사용해 비교하도록 수정

# 연관 이슈

- #95 

# 작업 내용

- 기존에 react-native-device-info 라이브러리를 참고해서 버전을 비교했는데 확인해보니 현재 앱 버전을 가져오는 라이브러리라고 함.
- 대신 react-native-version-check 라이브러리의 needUpdate 함수를 사용해 자동으로 앱스토어 버전을 가져와서 현재 앱 버전과 비교하도록 수정
- build.gradle 의 앱 버전을 낮춘 후 재빌드 후 테스트 결과 정상적으로 뜨는 것을 확인 
---
- 크롤링으로 가져오는 로직이라 호출 횟수가 많아지면 문제가 많이질 수 있어 업데이트 체크하는 로직 GOOGLE_CLOUD_INIT_INFO_URL 에서 가져와서 비교하도록 수정함

# 참고자료
> https://adjh54.tistory.com/455
