### PR TITLE
feat 102 - 이미지 로드 지연 현상 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "expo-constants": "~18.0.9",
     "expo-dev-client": "~6.0.12",
     "expo-font": "~14.0.8",
+    "expo-image": "~3.0.8",
     "expo-linear-gradient": "~15.0.7",
     "expo-localization": "~17.0.7",
     "expo-splash-screen": "~31.0.10",

--- a/src/components/atoms/Button.tsx
+++ b/src/components/atoms/Button.tsx
@@ -1,4 +1,5 @@
-import { View, Image, StyleSheet } from "react-native";
+import { View, StyleSheet } from 'react-native';
+import { Image } from 'expo-image';
 import TouchableScale, {
   TouchableScaleProps,
 } from 'react-native-touchable-scale';
@@ -20,7 +21,11 @@ const Button = {
       </View>
     );
   },
-  imgInButton: ({ children, src, ...props }: TouchableScaleProps & { src: string }) => {
+  imgInButton: ({
+    children,
+    src,
+    ...props
+  }: TouchableScaleProps & { src: string }) => {
     return (
       <TouchableScale
         onPress={props.onPress}
@@ -33,7 +38,7 @@ const Button = {
         <Image
           source={{ uri: src }}
           style={{ width: 30, height: 30, marginBottom: 4 }}
-          resizeMode="contain"
+          contentFit="contain"
         />
         {children}
       </TouchableScale>

--- a/src/components/atoms/HeaderLogo.tsx
+++ b/src/components/atoms/HeaderLogo.tsx
@@ -1,17 +1,28 @@
-import { StyleSheet, View, Image } from 'react-native';
+import { StyleSheet, View } from 'react-native';
+import { Image } from 'expo-image';
 
 const HeaderLogo = () => {
   return (
-    <View>
+    <View style={styles.container}>
       <Image
         style={styles.headerLogo}
         source={require('@assets/images/logo_default.png')} // header에 들어갈 로고이미지.
+        contentFit="contain"
       />
     </View>
   );
 };
 const styles = StyleSheet.create({
-  headerLogo: { height: '96%', resizeMode: 'contain' },
+  container: {
+    width: '100%',
+    height: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerLogo: {
+    width: 100,
+    height: '100%',
+  },
 });
 
 export default HeaderLogo;

--- a/src/components/atoms/ModalIconButton.tsx
+++ b/src/components/atoms/ModalIconButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Image, Text, TouchableOpacity, View, StyleSheet } from 'react-native';
+import { Text, TouchableOpacity, View, StyleSheet } from 'react-native';
+import { Image } from 'expo-image';
 import { IModalIconButton } from '@/types/atoms.type';
 
 const ModalIconButton = ({ markSelected, item }: IModalIconButton) => {

--- a/src/components/atoms/ResultItem.tsx
+++ b/src/components/atoms/ResultItem.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
-import { Image, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
+import { Image } from 'expo-image';
 import { font, os } from '@/style/font';
 import ArrowRightSvg from '@assets/svgs/arrow_right.svg';
 import { useNavigation } from '@react-navigation/native';
@@ -37,11 +38,12 @@ const ResultItem = ({ data }: { data: TPillData }) => {
               style={styles.pillImg}
               source={{
                 uri: data.ITEM_IMAGE,
-                cache: 'force-cache',
               }}
-              resizeMode="contain"
-              fadeDuration={100}
-              progressiveRenderingEnabled={true}
+              contentFit="contain"
+              transition={100}
+              cachePolicy="memory-disk"
+              priority="high"
+              recyclingKey={data.ITEM_SEQ}
             />
           )}
         </View>

--- a/src/components/atoms/SearchImageButton.tsx
+++ b/src/components/atoms/SearchImageButton.tsx
@@ -1,7 +1,8 @@
 import Button from '@/components/atoms/Button';
 import { font, os } from '@/style/font';
 import { useNavigation } from '@react-navigation/native';
-import { Image, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
+import { Image } from 'expo-image';
 import { Shadow } from 'react-native-shadow-2';
 
 const SearchImageButton = (): React.JSX.Element => {

--- a/src/components/atoms/StorageItem.tsx
+++ b/src/components/atoms/StorageItem.tsx
@@ -1,7 +1,8 @@
 import Button from '@/components/atoms/Button';
 import { windowWidth } from '@/components/organisms/Layout';
 import { font, os } from '@/style/font';
-import { Image, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
+import { Image } from 'expo-image';
 import ArrowRightSvg from '@assets/svgs/arrow_right.svg';
 import DeleteSvg from '@assets/svgs/exit.svg';
 import { useNavigation } from '@react-navigation/native';
@@ -9,7 +10,10 @@ import { useAlert } from '@/hooks/useAlert';
 import { usePillBox } from '@/hooks/usePillBox';
 import { IStorageItemProps } from '@/types/atoms.type';
 
-const StorageItem = ({ data, refresh }: IStorageItemProps): React.JSX.Element => {
+const StorageItem = ({
+  data,
+  refresh,
+}: IStorageItemProps): React.JSX.Element => {
   const nav: any = useNavigation();
   const { showAlert } = useAlert();
   const { delPill } = usePillBox();
@@ -109,8 +113,9 @@ const StorageItem = ({ data, refresh }: IStorageItemProps): React.JSX.Element =>
           {!!data.ITEM_IMAGE && (
             <Image
               style={styles.pillImg}
-              source={{ uri: data.ITEM_IMAGE, cache: 'only-if-cached' }}
-              resizeMode="contain"
+              source={{ uri: data.ITEM_IMAGE }}
+              contentFit="contain"
+              cachePolicy="disk"
             />
           )}
         </View>

--- a/src/components/organisms/MenuList.tsx
+++ b/src/components/organisms/MenuList.tsx
@@ -1,7 +1,8 @@
 import Button from '@/components/atoms/Button';
 import { font, os } from '@/style/font';
 import { useNavigation } from '@react-navigation/native';
-import { Image, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
+import { Image } from 'expo-image';
 import { Shadow } from 'react-native-shadow-2';
 import Toast from 'react-native-toast-message';
 

--- a/src/components/organisms/SearchButtonList.tsx
+++ b/src/components/organisms/SearchButtonList.tsx
@@ -1,5 +1,6 @@
 import Button from '@/components/atoms/Button';
-import { Image, View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet } from 'react-native';
+import { Image } from 'expo-image';
 import { font, os } from '@/style/font';
 import { useNavigation } from '@react-navigation/native';
 import { Shadow } from 'react-native-shadow-2';

--- a/src/components/organisms/SelectedMark.tsx
+++ b/src/components/organisms/SelectedMark.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { View, StyleSheet, Text, Modal, Image } from 'react-native';
+import { View, StyleSheet, Text, Modal } from 'react-native';
+import { Image } from 'expo-image';
 import { font, os } from '@/style/font';
 import Button from '@components/atoms/Button';
 import MarkModal from '@components/organisms/markModal/index';
@@ -49,7 +50,7 @@ const SelectingMark = () => {
                   : require('@/assets/images/noImage.png')
               }
               style={styles.markImage}
-              resizeMode="contain"
+              contentFit="contain"
             />
           </View>
         )}

--- a/src/components/screens/PillDetail.tsx
+++ b/src/components/screens/PillDetail.tsx
@@ -1,6 +1,7 @@
 import { font, os } from '@/style/font';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { View, ScrollView, StyleSheet, Image, Text } from 'react-native';
+import { View, ScrollView, StyleSheet, Text } from 'react-native';
+import { Image } from 'expo-image';
 import Toast from 'react-native-toast-message';
 
 import AddStorageSvg from '@assets/svgs/addStorage.svg';
@@ -120,8 +121,9 @@ const PillDetail = ({ route }: any): React.JSX.Element => {
             {data.ITEM_IMAGE && (
               <Image
                 style={styles.pillImg}
-                source={{ uri: data.ITEM_IMAGE, cache: 'only-if-cached' }}
-                resizeMode="contain"
+                source={{ uri: data.ITEM_IMAGE }}
+                contentFit="contain"
+                cachePolicy="disk"
               />
             )}
           </View>

--- a/src/components/screens/SearchId.tsx
+++ b/src/components/screens/SearchId.tsx
@@ -8,6 +8,7 @@ import Layout, {
 } from '@/components/organisms/Layout';
 import { useScreenStore } from '@/store/screen';
 import { useSearchIdStore } from '@/store/searchIdStore';
+import LoadingCircle from '@/components/atoms/LoadingCircle';
 
 const SearchIdList = lazy(() => import('@/components/organisms/SearchIdList'));
 
@@ -30,7 +31,13 @@ const SearchId = (): React.JSX.Element => {
 
   return (
     <Layout.default>
-      <Suspense fallback={<View style={styles.viewWrapper} />}>
+      <Suspense
+        fallback={
+          <View style={styles.viewWrapper}>
+            <LoadingCircle size="large" color="#6060dd" />
+          </View>
+        }
+      >
         <SearchIdList />
       </Suspense>
     </Layout.default>

--- a/src/components/screens/UpdateDB.tsx
+++ b/src/components/screens/UpdateDB.tsx
@@ -1,6 +1,7 @@
 import Layout from '@/components/organisms/Layout';
 import { useCallback, useEffect, useReducer } from 'react';
-import { Image, StyleSheet, Text, View, BackHandler } from 'react-native';
+import { StyleSheet, Text, View, BackHandler } from 'react-native';
+import { Image } from 'expo-image';
 import { font, os } from '@/style/font';
 import * as Progress from 'react-native-progress';
 import { DBResClient } from '@/api/client/DBResClient';
@@ -185,6 +186,7 @@ const UpdateDB = (): React.JSX.Element => {
           <Image
             style={styles.logo}
             source={require('@assets/images/logo_default.png')}
+            contentFit="contain"
           />
         </View>
         <View style={styles.infoViewWrapper}>
@@ -217,7 +219,7 @@ const styles = StyleSheet.create({
   },
   infoViewWrapper: { alignItems: 'center', flex: 1, justifyContent: 'center' },
   initViewWrapper: { flex: 1 },
-  logo: { height: 150, resizeMode: 'contain', width: 150 },
+  logo: { height: 150, width: 150 },
   logoViewWrapper: { alignItems: 'center', flex: 1, justifyContent: 'center' },
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3927,6 +3927,11 @@ expo-font@~14.0.8:
   dependencies:
     fontfaceobserver "^2.1.0"
 
+expo-image@~3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/expo-image/-/expo-image-3.0.8.tgz#ec76f7a300712cc659b197e5478362426e411424"
+  integrity sha512-L83fTHVjvE5hACxUXPk3dpABteI/IypeqxKMeOAAcT2eB/jbqT53ddsYKEvKAP86eoByQ7+TCtw9AOUizEtaTQ==
+
 expo-json-utils@~0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/expo-json-utils/-/expo-json-utils-0.15.0.tgz#6723574814b9e6b0a90e4e23662be76123ab6ae9"


### PR DESCRIPTION
# 연관 이슈

- #102 

# 작업 내용

- expo-image 라이브러리 추가
- react-native의 Image 컴포넌트를 expo-image의 Image 컴포넌트로 교체
- 세부 설정은 유지
- 식별 검색 화면에 lazy 로딩 시 indicator 추가

# 참고 자료

- ui 변경사항 없음

# 비고

-
